### PR TITLE
fix: Resolve typescript packages

### DIFF
--- a/dapps.js
+++ b/dapps.js
@@ -83,6 +83,7 @@ module.exports = {
   },
   settings: {
     'import/resolver': {
+      typescript: true,
       node: {
         paths: ['./src'],
       },


### PR DESCRIPTION
This PR fixes the eslint error `Unable to resolve path to module` when loading typescript packages.