### PR TITLE
feat: core services config

### DIFF
--- a/core-services.js
+++ b/core-services.js
@@ -1,0 +1,117 @@
+module.exports = {
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: "module",
+  },
+  env: {
+    node: true,
+    es6: true,
+  },
+  plugins: [
+    "@typescript-eslint",
+    "prettier",
+    "import",
+    "autofix",
+  ],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+    "plugin:import/recommended",
+    "plugin:import/typescript",
+  ],
+  rules: {
+    "eqeqeq": ["error", "always"],
+    "@typescript-eslint/no-inferrable-types": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-namespace": "error",
+    "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
+    "@typescript-eslint/array-type": ["error", { "default": "array-simple" }],
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "ignoreRestSiblings": true,
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
+    "import/no-named-as-default-member": "off",
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        types: {
+          "{}": {
+            message: "Use Record<string, unknown> instead of {}",
+            fixWith: "Record<string, unknown>",
+          },
+        },
+      },
+    ],
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "no-restricted-imports": "off",
+    "@typescript-eslint/no-restricted-imports": "off",
+    "autofix/no-debugger": "error",
+    "sort-imports": [
+      "error",
+      {
+        ignoreDeclarationSort: true,
+        memberSyntaxSortOrder: ["none", "all", "multiple", "single"],
+        allowSeparatedGroups: true,
+      },
+    ],
+    "import/order": [
+      "error",
+      {
+        groups: [
+          "builtin",
+          "external",
+          "internal",
+          ["sibling", "parent"],
+          "index",
+          "object",
+          "type",
+          "unknown",
+        ],
+        pathGroupsExcludedImportTypes: [],
+        pathGroups: [
+          {
+            pattern: "@well-known-components/*",
+            group: "internal",
+            position: "before",
+          },
+          {
+            pattern: "@dcl/*",
+            group: "internal",
+          },
+          {
+            pattern: "decentraland-*",
+            group: "internal",
+          },
+        ],
+        "newlines-between": "never",
+        alphabetize: {
+          order: "asc",
+          caseInsensitive: true,
+        },
+      },
+    ],
+  },
+  settings: {
+    "import/parsers": {
+      "@typescript-eslint/parser": [".ts", ".tsx"],
+    },
+    "import/resolver": {
+      typescript: {
+        alwaysTryTypes: true,
+      },
+      node: {},
+    },
+  },
+};


### PR DESCRIPTION
# ESLint Configuration for Core Services

This adds a new ESLint configuration specifically tailored for Decentraland's Core team backend services. The config focuses on TypeScript best practices and code consistency for server-side development.

## What's included:

### Type Safety & Code Quality:
- **`eqeqeq: ["error", "always"]`** - Enforces strict equality (`===`) over loose equality (`==`)
- **`@typescript-eslint/no-explicit-any: "error"`** - Prevents `any` type usage to maintain type safety
- **`@typescript-eslint/no-floating-promises: "error"`** - Requires proper promise handling to avoid unhandled rejections
- **`@typescript-eslint/no-namespace: "error"`** - Blocks TypeScript namespaces (prefer modules instead)
- **`autofix/no-debugger: "error"`** - Removes debugger statements from production code

### TypeScript Consistency:
- **`@typescript-eslint/prefer-optional-chain: "error"`** - Prefers optional chaining (`?.`) over verbose null checks
- **`@typescript-eslint/consistent-type-imports: "error"`** - Enforces `import type` for type-only imports
- **`@typescript-eslint/consistent-type-definitions: ["error", "interface"]`** - Standardizes on `interface` over `type` for object definitions
- **`@typescript-eslint/array-type: ["error", { "default": "array-simple" }]`** - Uses `T[]` syntax for array types instead of `Array<T>`
- **`@typescript-eslint/ban-types`** - Replaces `{}` with `Record<string, unknown>` for better type clarity

### Import Management:
- **`sort-imports`** - Automatically sorts imports by syntax type (`none` → `all` → `multiple` → `single`)
- **`import/order`** - Groups imports in order: Node built-ins → external packages → internal modules → relative imports
- **`pathGroups`** - Handles Decentraland-specific packages (`@well-known-components/*`, `@dcl/*`, `decentraland-*`) as internal dependencies
- **`alphabetize`** - Alphabetizes imports within each group
- **`newlines-between: "never"`** - No blank lines between import groups

### Variable Management:
- **`@typescript-eslint/no-unused-vars`** - Warns on unused variables but ignores those prefixed with `_`

### Configuration:
- **`parser: "@typescript-eslint/parser"`** - Uses TypeScript parser for `.ts/.tsx` files
- **`import/resolver`** - Resolves imports through TypeScript and Node.js resolvers
- **`alwaysTryTypes: true`** - Always looks for TypeScript declaration files

